### PR TITLE
touchups for MacOS: refine brew SDL2 config, Mx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Note:
 Use [Homebrew](https://brew.sh/):
 
 ```sh
-brew install sdl2
+brew install sdl2 pkg-config
 ```
 Note: 
 On MacOS you need to include (uncomment in provided example [platformio.ini](./platformio.ini) file) these lines in your platformio.ini file to import the drivers:
 ```
   ; SDL2 includes
-  !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
-  !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
+  !pkg-config --cflags SDL2
+  !pkg-config --libs SDL2
 ```
 
 **Windows**

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,8 +24,8 @@ build_flags =
   -D LVGL_USE_V9=0  ; lvgl v9
 
   ; SDL2 includes, uncomment the next two lines on MAC OS if you intalled sdl via homebrew
-  ; !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
-  ; !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
+  ; !pkg-config --cflags SDL2
+  ; !pkg-config --libs SDL2
 lib_deps = 
 	https://github.com/m5stack/M5GFX#develop
   lvgl=https://github.com/lvgl/lvgl/archive/refs/tags/v8.3.0.zip  ; lvgl v8
@@ -35,6 +35,8 @@ lib_archive = false
 
 [env:emulator_common]
 build_flags =
+  ; uncomment the next line if running on MacOS Mx (arm64 architecture)
+  ; -arch arm64
   -l SDL2
   ${env.build_flags}
   -D M5GFX_SHOW_FRAME


### PR DESCRIPTION
great job!

here are some touchups for MacOS:
- use pgk-config for brew library cflags and libs
- make it build on MacOS M1 ff (arm64)

are you prepared to accept a PR for M5Stack Paper which is EOL?

best regards
Michael